### PR TITLE
- .dart file imports not from packages are not allowed, since they ca…

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -23,5 +23,7 @@
     "unping-ui",
     "jdde",
     "shadcn",
+    "cupertino",
+    "Cupertino",
   ]
 }

--- a/lib/src/services/repository_post_clone_service.dart
+++ b/lib/src/services/repository_post_clone_service.dart
@@ -352,7 +352,7 @@ vars:
         
         if (inImports && (trimmedLine.startsWith('import ') || trimmedLine.startsWith('export '))) {
           // Skip relative imports between component files
-          if (!trimmedLine.contains('./') && !trimmedLine.contains('../')) {
+          if (!trimmedLine.contains('./') && !trimmedLine.contains('../') && !(!trimmedLine.contains(':') && trimmedLine.contains('.dart'))) {
             fileImports.add(line);
             imports.add(trimmedLine);
           }


### PR DESCRIPTION
## Description
relative imports from the same directly should not be allowed, since we merge all content together into one file.
I excluded imports to be included, when they're referenced to a .dart file and dont have a ":" in there, to ensure theyre not from a package


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
